### PR TITLE
fix: Switch deliverytime metric to histogram

### DIFF
--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -14,10 +14,11 @@ var (
 	}, []string{"messageID", "reason", "errorMessage", "severity"},
 	)
 
-	DeliveryTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	DeliveryTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "delivery_time_seconds",
 		Namespace: namespace,
 		Help:      "The time took for an email to actually got delivered from the time that got accepted in mailgun",
-	}, []string{"message_id"},
+		Buckets:   []float64{0.5, 1, 2, 5, 10, 20, 40, 60},
+	}, []string{"domain"},
 	)
 )

--- a/pkg/mailgun/mailgun.go
+++ b/pkg/mailgun/mailgun.go
@@ -60,7 +60,7 @@ func RecordDeliverySpeed(accepted []*events.Accepted, delivered []*events.Delive
 		for _, d := range delivered {
 			if d.Message.Headers.MessageID == a.Message.Headers.MessageID {
 				logger.Debug("Delivery Succeeded", "MessageID", a.Message.Headers.MessageID, "Accepted at", a.GetTimestamp(), "Delivered at", d.GetTimestamp(), "Delivery time", d.Timestamp-a.Timestamp)
-				metrics.DeliveryTime.WithLabelValues(a.Message.Headers.MessageID).Set(float64(d.Timestamp - a.Timestamp))
+				metrics.DeliveryTime.WithLabelValues(config.FromEnv().Domain).Observe(float64(d.Timestamp - a.Timestamp))
 				break
 			}
 		}


### PR DESCRIPTION
Let's switch to histogram metric for the email delivery time in order
to have better and more accurate "latency" results