### PR TITLE
feat: add local build and push support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ build: buildlinux darwinbuild
 build-image:
 	docker build -t gathertown/prometheus-mailgun-events-exporter:latest .
 
+# Build and push multi-arch image (linux/amd64, linux/arm64). Requires: docker login
+push-multi-arch:
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-t gathertown/prometheus-mailgun-events-exporter:latest \
+		--push .
+
 run: build
 	go run ./cmd/main.go
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build tooling-only change; risk is limited to Docker image publishing behavior (tags/platforms) and does not affect runtime code.
> 
> **Overview**
> Adds a new Makefile target, `push-multi-arch`, to **build and push** a multi-architecture Docker image (linux/amd64 and linux/arm64) using `docker buildx`.
> 
> No application code changes; this PR only extends local release tooling for publishing the `:latest` image tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4808e342075990e6bcd84d20328e87ac1cfcb90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->